### PR TITLE
Update Client.php

### DIFF
--- a/src/Qiniu/Http/Client.php
+++ b/src/Qiniu/Http/Client.php
@@ -83,9 +83,14 @@ final class Client
             CURLOPT_HEADER => true,
             CURLOPT_NOBODY => false,
             CURLOPT_CUSTOMREQUEST  => $request->method,
-            CURLOPT_FOLLOWLOCATION => 1,
             CURLOPT_URL => $request->url
         );
+
+        // Handle open_basedir & safe mode
+        if (!ini_get('safe_mode') && !ini_get('open_basedir'))
+        {
+            $options[CURLOPT_FOLLOWLOCATION] = true;
+        }
         
         if (!empty($request->headers)) {
             $headers = array();


### PR DESCRIPTION
开启安全模式或者设置可操作目录树时，设置CURLOPT_FOLLOWLOCATION会报错
